### PR TITLE
quick bug fixes

### DIFF
--- a/www/css/search-bar.css
+++ b/www/css/search-bar.css
@@ -16,6 +16,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  background-color: rgba(0,0,0,0.4);
 }
 
 #search-bar > section {

--- a/www/css/search-bar.css
+++ b/www/css/search-bar.css
@@ -39,7 +39,7 @@
 
   background-color: var(--bg-color);
 
-  opacity: 0.7;
+  opacity: 0.9;
 }
 
 #search-bar > section > span {
@@ -66,7 +66,7 @@
 
   background-color: var(--bg-color);
 
-  opacity: 0.4;
+  opacity: 0.6;
 }
 
 #search-bar > section > span:after {

--- a/www/css/text-bubbles.css
+++ b/www/css/text-bubbles.css
@@ -65,7 +65,7 @@
   position: relative;
   color: var(--fg-color);
   text-decoration: none;
-  cursor: pointer !important;
+  cursor: pointer;
   transition: color .5s ease, border .5s ease;
 
   /*underline*/

--- a/www/css/text-bubbles.css
+++ b/www/css/text-bubbles.css
@@ -65,21 +65,30 @@
   position: relative;
   color: var(--fg-color);
   text-decoration: none;
+  cursor: pointer !important;
   transition: color .5s ease, border .5s ease;
 
   /*underline*/
-  border-bottom: 1px solid var(--fg-color);
-  text-shadow: 2px 2px var(--bg-color), 2px -2px var(--bg-color), -2px 2px var(--bg-color), -2px -2px var(--bg-color);
+  text-decoration: underline;
+  text-underline-position: under;
 }
 .text-bubble > section a:hover {
   color: var(--netizen-match-color);
-  border-bottom: 1px solid var(--netizen-match-color);
 }
 .text-bubble > section a:active {
   color: var(--netizen-attribute);
 }
 .text-bubble > section a:active:after {
   background-color: var(--netizen-attribute);
+}
+.text-bubble > section a code {
+  text-decoration: underline;
+  text-underline-position: under;
+  cursor: pointer;
+  transition: color .5s ease;
+}
+.text-bubble > section a:hover code {
+  color: var(--netizen-match-color);
 }
 
 
@@ -140,6 +149,10 @@
   font-size: 20px;
   line-height: 1.2em;
   cursor: pointer;
+}
+
+.text-bubble > section h1 a:hover code {
+  color: inherit;
 }
 
 .text-bubble > section h1:before {

--- a/www/js/SearchBar.js
+++ b/www/js/SearchBar.js
@@ -103,7 +103,6 @@ class SearchBar {
     setTimeout(() => {
       this.ele.querySelector('input').focus()
       this.ele.style.opacity = 1
-      this.netnet.style.filter = 'blur(25px)'
     }, 100)
   }
 

--- a/www/widgets/MenuFunctions.js
+++ b/www/widgets/MenuFunctions.js
@@ -315,12 +315,26 @@ class MenuFunctions extends Widget {
       title.textContent = sub
       title.tabIndex = 0
       title.addEventListener('click', () => {
-        this.toggleSubMenu(div.id)
+        for (const sub in this.subs) {
+          if (title.textContent === sub) {
+            this.toggleSubMenu(div.id)
+          } else {
+            const id = `func-menu-${sub.replace(/ /g, '-')}`
+            this.toggleSubMenu(id, 'close')
+          }
+        }
         title.blur()
       })
       title.addEventListener('keypress', (e) => {
         if (e.which === 13) {
-          this.toggleSubMenu(div.id)
+          for (const sub in this.subs) {
+            if (title.textContent === sub) {
+              this.toggleSubMenu(div.id)
+            } else {
+              const id = `func-menu-${sub.replace(/ /g, '-')}`
+              this.toggleSubMenu(id, 'close')
+            }
+          }
         }
       })
       div.appendChild(title)


### PR DESCRIPTION
Didn't manage to address everything, but this push includes some quick style fixes:
- links inside of text bubbles are now using regular ol' `text-decoration: underline`. no more wonky text shadows on links that have code inside
- remove blurred background on search, replace with an overlay
- function menu: only one dropdown opens at a time