### PR TITLE
fixed filesize upload limit

### DIFF
--- a/my_modules/github.js
+++ b/my_modules/github.js
@@ -2,13 +2,7 @@ const axios = require('axios')
 const triplesec = require('triplesec')
 const { Octokit } = require('@octokit/core')
 const express = require('express')
-const bodyParser = require('body-parser')
 const router = express.Router()
-const cookieParser = require('cookie-parser')
-// const multer = require('multer')
-
-router.use(cookieParser())
-router.use(bodyParser.json({ limit: '10mb' }))
 
 function decryptToken (req, res, cb) {
   const token = req.cookies.AuthTok

--- a/my_modules/routes.js
+++ b/my_modules/routes.js
@@ -1,15 +1,10 @@
 const express = require('express')
-const bodyParser = require('body-parser')
 const router = express.Router()
 const path = require('path')
-const cookieParser = require('cookie-parser')
 const fs = require('fs')
 const exec = require('child_process').exec
 const utils = require('./utils.js')
 const axios = require('axios')
-
-router.use(cookieParser())
-router.use(bodyParser.json({ limit: '10mb' }))
 
 // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ //
 // // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\

--- a/server.js
+++ b/server.js
@@ -11,6 +11,10 @@ const GITHUB = require('./my_modules/github.js')
 const SOCKETS = require('./my_modules/sockets.js')
 const PORT = process.env.PORT || 8001
 
+const cookieParser = require('cookie-parser')
+app.use(cookieParser())
+app.use(express.json({ limit: '50mb' })) // GitHub's limit is 100mb
+
 ANALYTICS.setup(app, {
   path: `${__dirname}/data/analytics`,
   admin: {


### PR DESCRIPTION
recently students started running into an issue where they couldn't upload files larger than 1MB or so...
<img width="2668" alt="Screen Shot 2022-10-06 at 12 42 34 PM" src="https://user-images.githubusercontent.com/2506806/194717885-3d8bd24a-ff8d-4c11-8a8a-6cb8c6557d1d.png">

as made clear by [most of the answers on stackoverflow](https://stackoverflow.com/questions/19917401/error-request-entity-too-large) for this issue, the solution is simply something like `app.use(bodyParser.json({ limit: "50mb" }))` where `50mb` is the new filesize limit. howerver, we already did this when we first created the AssetManager, && it worked... until it didn't anymore.

this [answer](https://stackoverflow.com/a/55012934/1104148) led me down the right path to solving the issue. apparently u only want to run `app.use(express.json())` once, i had assumed that if we do something like `router.use(express.json())` it was scoped to the module, but it actually effects the entire server. i had a call to the bodyParser in both `routes.js` && `github.js` modules, both had the the limit option set though... but then i realized that deep inside the [StatsNotTracks](https://github.com/nbriz/StatsNotTracks) analytics i wrote there was a call to [`router.use(bodyParser.json())`](https://github.com/nbriz/StatsNotTracks/blob/main/js/rest-api.js#L9) && because in our `server.js` file the= analytics setup was running before our `routes.js` && `github.js` it was taking precedence (&& not setting a higher file size limit). this is why things were working fine until they weren't anymore (ie. until after we added the analytics code)

i was able to fix this by simply declaring the `app.use(express.json({ limit: '50mb' }))` on the root `server.js` file (rather than in the `routes.js` && `github.js` files) before running the analytics setup.