### PR TITLE
issue 201: searchbar styles

### DIFF
--- a/www/css/search-bar.css
+++ b/www/css/search-bar.css
@@ -69,18 +69,26 @@
   opacity: 0.6;
 }
 
-#search-bar > section > span:after {
-  content: '◕ ◞ ◕ ';
+#search-bar > section > span > label {
   display: block;
-  position: absolute;
-  left: 15px;
-  top: 50%;
-  transform: translateY(-50%);
+  width: 87px;
+  padding-top: 18px;
+  padding-left: 13px;
+}
 
-  color: var(--netizen-meta);
-  font-size: 25px;
-
+#search-bar > section > span > label .face {
+  display: inline-block;
+  width: 17px;
+  height: 17px;
   opacity: 0.9;
+  background-color: var(--netizen-meta);
+  -webkit-mask: url(./../images/faces/◕.svg) no-repeat center;
+  mask: url(./../images/faces/◕.svg) no-repeat center;
+}
+
+#search-bar > section > span > label .face--mouth {
+  -webkit-mask: url(./../images/faces/◞.svg) no-repeat center;
+  mask: url(./../images/faces/◞.svg) no-repeat center;
 }
 
 #search-bar > section > span > input {

--- a/www/css/styles.css
+++ b/www/css/styles.css
@@ -197,6 +197,16 @@ button {
   scrollbar-width: thin;
 }
 
+/* screen reader text cc: https://css-tricks.com/inclusively-hidden */
+.screen-reader-only:not(:focus):not(:active) {
+  clip: rect(0 0 0 0); 
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap; 
+  width: 1px;
+}
 
 /* BROWSERFEST BUTTON */
 .opt-rainbow-bg {

--- a/www/js/SearchBar.js
+++ b/www/js/SearchBar.js
@@ -336,7 +336,15 @@ class SearchBar {
     this.ele.innerHTML = `
       <div id="search-overlay"></div>
       <section>
-        <span><input placeholder="what are you looking for?"></span>
+        <span>
+          <input placeholder="what are you looking for?">
+          <label>
+            <span class="screen-reader-only">netnet: what are you looking for?</span>
+            <span class="face"></span>
+            <span class="face face--mouth"></span>
+            <span class="face"></span>
+          </label>
+        </span>
         <div id="search-results" tabindex="-1"></div>
       </section>
     `


### PR DESCRIPTION
netnet's face was off in searchbar in firefox on mac.

im fixing this by using our face svgs -- had to get a little bit hacky with it as to not bloat the js-markup (didn't want to put them inline) and also be able to change fill color as needed. to do this, i'm using the svgs as a mask in css and then setting the `background-color` of the face element to `var(--netizen-meta)`.

additionally, i changed netnet's face into a `<label>` to better inform the neighboring `<input>` element. the descriptive text inside the label takes a class `.screen-reader-only` to make it invisible unless using a screen reader.