### PR TITLE
Issue #237: error loading older examples

### DIFF
--- a/www/widgets/demo-example-maker/convo.js
+++ b/www/widgets/demo-example-maker/convo.js
@@ -1,19 +1,20 @@
-/* global utils, NNW */
+/* global NNE */
 window.CONVOS['demo-example-maker'] = (self) => {
     return [{
-        id: 'before-loading-json',
-        content: `Looks like you want to upload a new example. Are you sure you want to overwrite your current session?`,
-        options: { 
-            'yes!': (e) => {
-                self._uploadJSON(self.loaded)
-                e.hide()
-            },
-            'load it in a new tab': (e) => {
-                const l = window.location
-                const str = JSON.stringify(self.loaded)
-                const url = `${l.protocol}//${l.host}/?dem=true#example/${NNE._encode(str)}`
-                window.open(url, '_blank')
-            },
-            'oops, no thank you': (e) => e.hide() }
+      id: 'before-loading-json',
+      content: 'Looks like you want to upload a new example. Are you sure you want to overwrite your current session?',
+      options: {
+        'yes!': (e) => {
+          self._uploadJSON(self.loaded)
+          e.hide()
+        },
+        'load it in a new tab': (e) => {
+          const l = window.location
+          const str = JSON.stringify(self.loaded)
+          const url = `${l.protocol}//${l.host}/?dem=true#example/${NNE._encode(str)}`
+          window.open(url, '_blank')
+        },
+        'oops, no thank you': (e) => e.hide()
+      }
     }]
-}
+  }

--- a/www/widgets/demo-example-maker/convo.js
+++ b/www/widgets/demo-example-maker/convo.js
@@ -6,7 +6,7 @@ window.CONVOS['demo-example-maker'] = (self) => {
         options: { 
             'yes!': (e) => {
                 self._uploadJSON(self.loaded)
-                e.goTo('loaded-json')
+                e.hide()
             },
             'load it in a new tab': (e) => {
                 const l = window.location

--- a/www/widgets/demo-example-maker/index.js
+++ b/www/widgets/demo-example-maker/index.js
@@ -339,7 +339,7 @@ class DemoExampleMaker extends Widget {
     } else {
       this.$('[name="dem-s-title"]').value = null
       this.$('[name="dem-s-focus"]').value = null
-      this._text.code = null
+      this._text.code = ''
       this._selectStep(null)
     }
   }


### PR DESCRIPTION
Error was coming from line 342 `this._text.code = null`. It was unhappy about it being null, so I set it to an empty string. #237 

Also after choosing `yes!`, I have it hide the convo. The ' e.goTo('loaded-json')' wasn't referencing anything. 