### PR TITLE
Issue #237: dashed syntax for line number highlights

### DIFF
--- a/www/widgets/demo-example-maker/index.js
+++ b/www/widgets/demo-example-maker/index.js
@@ -11,7 +11,7 @@ class DemoExampleMaker extends Widget {
     this._data = {
       name: null, toc: true, tags: [], layout: 'dock-left', key: null, code: null, steps: []
     }
-    //this.loaded = null
+    // this.loaded = null
     Convo.load(this.key, () => { this.convos = window.CONVOS[this.key](this) })
     utils.get('api/examples', (res) => {
       // this._data.key = Math.max(...Object.keys(res.data)) + 1
@@ -297,10 +297,20 @@ class DemoExampleMaker extends Widget {
     const layout = this._data.layout
     const info = this._data.steps.map(s => {
       if (s.focus && typeof s.focus === 'string') {
-        s.focus = s.focus.split(',').map(n => Number(n))
+        s.focus = s.focus.split(',').flatMap(f => {
+          console.log(f)
+          if (f.includes('-')) {
+            const [start, end] = f.split('-').map(n => Number(n))
+            console.log(Array.from({ length: end - start + 1 }, (_, i) => start + i))
+            return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+          } else {
+            return Number(f)
+          }
+        })
       }
       return s
     })
+
     const code = `#code/${NNE._encode(NNE.code)}`
     return { name, toc, tags, layout, key, code, info }
   }

--- a/www/widgets/demo-example-maker/index.js
+++ b/www/widgets/demo-example-maker/index.js
@@ -238,7 +238,14 @@ class DemoExampleMaker extends Widget {
   _previewStep (step) {
     window.convo = new Convo({ content: this._text.code })
     if (this.$('[name="dem-s-focus"]').value.length > 0) {
-      const lines = this.$('[name="dem-s-focus"]').value.match(/\d+/g).map(Number)
+      const lines = this.$('[name="dem-s-focus"]').value.split(',').flatMap(f => {
+        if (f.includes('-')) {
+          const [start, end] = f.split('-').map(n => Number(n))
+          return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+        } else {
+          return Number(f)
+        }
+      })
       NNE.spotlight([...lines])
     } else NNE.spotlight(null)
   }
@@ -298,10 +305,8 @@ class DemoExampleMaker extends Widget {
     const info = this._data.steps.map(s => {
       if (s.focus && typeof s.focus === 'string') {
         s.focus = s.focus.split(',').flatMap(f => {
-          console.log(f)
           if (f.includes('-')) {
             const [start, end] = f.split('-').map(n => Number(n))
-            console.log(Array.from({ length: end - start + 1 }, (_, i) => start + i))
             return Array.from({ length: end - start + 1 }, (_, i) => start + i)
           } else {
             return Number(f)


### PR DESCRIPTION
Added extra `if` statement so when `_getData` is generated it will accept dashed values (ex: `5-8`). Everything worked when downloading JSON & generating link + running example #237 