### PR TITLE
Fixed reorderable steps bug + added new styling

### DIFF
--- a/www/custom-elements/misc/reorderable-list/index.js
+++ b/www/custom-elements/misc/reorderable-list/index.js
@@ -196,9 +196,9 @@ class ReorderableList extends HTMLElement {
   }
 
   updateLastStep (steps = [...this.querySelectorAll('.rl-step')]) {
-    const previousLastStep = document.querySelector(".rl-last-step")
-    previousLastStep?.classList.remove("rl-last-step");
-    steps[steps.length - 1]?.classList.add("rl-last-step");
+    const previousLastStep = document.querySelector('.rl-last-step')
+    previousLastStep?.classList.remove('rl-last-step')
+    steps[steps.length - 1]?.classList.add('rl-last-step')
   }
 
   selectStep (step, container) {
@@ -220,26 +220,26 @@ class ReorderableList extends HTMLElement {
   }
 
   moveSteps (step, up) {
-    const steps = step.parentNode.querySelectorAll('.rl-step');
-    const currentIndex = Number(step.dataset.id);
-    const newIndex = up ? currentIndex - 1 : currentIndex + 1;
+    const steps = step.parentNode.querySelectorAll('.rl-step')
+    const currentIndex = Number(step.dataset.id)
+    const newIndex = up ? currentIndex - 1 : currentIndex + 1
 
     if (newIndex < 0 || newIndex >= steps.length) {
-      console.warn("Cannot move step further in this direction");
-      return;
+      console.warn('Cannot move step further in this direction')
+      return
     }
 
-    const parent = step.parentNode;
-    const targetStep = steps[newIndex];
+    const parent = step.parentNode
+    const targetStep = steps[newIndex]
 
     if (up) {
-      parent.insertBefore(step, targetStep);
+      parent.insertBefore(step, targetStep)
     } else {
-      parent.insertBefore(targetStep, step);
+      parent.insertBefore(targetStep, step)
     }
 
-    step.dataset.id = newIndex;
-    targetStep.dataset.id = currentIndex;
+    step.dataset.id = newIndex
+    targetStep.dataset.id = currentIndex
 
     WIDGETS[this.widget]._updateStep({
       oldIdx: currentIndex,

--- a/www/custom-elements/misc/reorderable-list/index.js
+++ b/www/custom-elements/misc/reorderable-list/index.js
@@ -15,7 +15,7 @@ class ReorderableList extends HTMLElement {
                     <p class="rl-s-i">0.</p>
                     <p class="rl-s-t">getting started</p>
                 </div>
-                <p><i class="arrow down"></i></p>
+                <p><i class="rl-arrow rl-down"></i></p>
             </div>
             <ul class="rl-list">
             </ul
@@ -75,6 +75,7 @@ class ReorderableList extends HTMLElement {
       step.dataset.id = index
       step.querySelector('.rl-s-i').textContent = index.toString()
     })
+    this.updateLastStep(steps)
   }
 
   dropdownActivated () {
@@ -105,8 +106,8 @@ class ReorderableList extends HTMLElement {
             <div class="rl-info">
                 <img class="rl-info-icon" src="/assets/images/widgets/info-button.svg" activated="false" />
                 <div class="rl-info-menu">
-                    <p><i class="arrow up"></i></p>
-                    <p><i class="arrow down"></i></p>
+                    <p class="rl-up-p" ><i class="rl-arrow rl-up"></i></p>
+                    <p class="rl-down-p"><i class="rl-arrow rl-down"></i></p>
                     <img class="rl-trash-can" src="/assets/images/widgets/trash.svg"/>
                 </div>
             </div>
@@ -123,11 +124,11 @@ class ReorderableList extends HTMLElement {
       info.querySelector('.rl-info-menu').style.paddingLeft = '0'
     })
 
-    step.querySelector('.arrow.down').addEventListener('click', () => {
+    step.querySelector('.rl-down-p').addEventListener('click', () => {
       this.moveSteps(step)
     })
 
-    step.querySelector('.arrow.up').addEventListener('click', () => {
+    step.querySelector('.rl-up-p').addEventListener('click', () => {
       this.moveSteps(step, 'up')
     })
 
@@ -162,6 +163,7 @@ class ReorderableList extends HTMLElement {
     highlightedStep.querySelector('.rl-s-t').textContent = data.title
 
     this.querySelector('.rl-list').appendChild(step)
+    this.updateLastStep()
   }
 
   updateStep (data, remove) {
@@ -193,6 +195,12 @@ class ReorderableList extends HTMLElement {
     }
   }
 
+  updateLastStep (steps = [...this.querySelectorAll('.rl-step')]) {
+    const previousLastStep = document.querySelector(".rl-last-step")
+    previousLastStep?.classList.remove("rl-last-step");
+    steps[steps.length - 1]?.classList.add("rl-last-step");
+  }
+
   selectStep (step, container) {
     if (step === 0) {
       step = document.querySelector('.rl-step:nth-of-type(1)')
@@ -212,42 +220,33 @@ class ReorderableList extends HTMLElement {
   }
 
   moveSteps (step, up) {
-    const steps = step.parentNode.querySelectorAll('.rl-step')
-    const currentIndex = Number(step.dataset.id)
-    const isFirst = currentIndex === 0
-    const isSecondToFirst = currentIndex === 1
-    const isSecondToLast = currentIndex === steps.length - 2
-    const isLast = currentIndex === steps.length - 1
+    const steps = step.parentNode.querySelectorAll('.rl-step');
+    const currentIndex = Number(step.dataset.id);
+    const newIndex = up ? currentIndex - 1 : currentIndex + 1;
 
-    const updateStepAndMove = (newIndex) => {
-      WIDGETS[this.widget]._updateStep({
-        oldIdx: currentIndex,
-        newIdx: newIndex
-      })
-      if (isSecondToLast) {
-        // last element
-        step.parentNode.appendChild(step)
-      } else {
-        const refStep = steps[newIndex]
-        step.parentNode.insertBefore(step, refStep)
-      }
-      this.updateList()
-      this.selectStep(step, this.querySelector('.rl-h-text'))
+    if (newIndex < 0 || newIndex >= steps.length) {
+      console.warn("Cannot move step further in this direction");
+      return;
     }
+
+    const parent = step.parentNode;
+    const targetStep = steps[newIndex];
 
     if (up) {
-      if (isSecondToFirst) {
-        updateStepAndMove(0)
-      } else if (!isFirst) {
-        updateStepAndMove(currentIndex - 1)
-      }
+      parent.insertBefore(step, targetStep);
     } else {
-      if (isSecondToLast) {
-        updateStepAndMove(currentIndex + 1)
-      } else if (!isLast) {
-        updateStepAndMove(currentIndex + 2)
-      }
+      parent.insertBefore(targetStep, step);
     }
+
+    step.dataset.id = newIndex;
+    targetStep.dataset.id = currentIndex;
+
+    WIDGETS[this.widget]._updateStep({
+      oldIdx: currentIndex,
+      newIdx: newIndex
+    })
+    this.updateList()
+    this.selectStep(step, this.querySelector('.rl-h-text'))
   }
 }
 

--- a/www/custom-elements/misc/reorderable-list/styles.css
+++ b/www/custom-elements/misc/reorderable-list/styles.css
@@ -44,7 +44,8 @@ reorderable-list {
     scrollbar-width: thin;
 }
 
-.reorderable-list .rl-list .rl-step {
+.rl-list .rl-step {
+    cursor: grab;
     background-color: var(--netizen-meta);
     border-radius: 5px;
     color: var(--bg-color);
@@ -53,6 +54,10 @@ reorderable-list {
     margin: .15rem;
     padding: .25rem;
     width: 97%;
+}
+
+.rl-step.dragging {
+    background-color: var(--netizen-text);
 }
 
 .rl-step .rl-details {
@@ -75,6 +80,7 @@ reorderable-list {
 }
 
 .rl-info {
+    cursor: pointer;
     display: flex;
     z-index: 200;
 }
@@ -90,8 +96,7 @@ reorderable-list {
 }
 
 .reorderable-list .rl-info-menu {
-    /* position: relative; */
-    /* left: -50px; */
+    cursor: pointer;
     display: flex;
     background-color: var(--netizen-meta);
     box-sizing: border-box;
@@ -107,36 +112,44 @@ reorderable-list {
 }
 
 .rl-info-menu .rl-trash-can {
+    cursor: pointer;
     fill: var(--bg-color);
     overflow: none;
 }
 
-.rl-info-menu .arrow {
+.rl-info-menu .rl-arrow {
     border-color: solid var(--bg-color);
     margin: 0 .25rem;
     padding: 7px;
 }
 
-.rl-info-menu .up {
+.rl-info-menu .rl-up {
     margin-top: 7px;
 }
 
-.arrow {
+.rl-arrow {
     border: solid var(--netizen-meta);
     border-width: 0 3px 3px 0;
     border-radius: 3px;
+    cursor: pointer;
     display: inline-block;
     padding: 5px;
     margin-right: .4rem;
 }
 
-.down {
+.rl-down {
     transform: rotate(45deg);
     -webkit-transform: rotate(45deg);
 }
 
-.up {
+.rl-up {
     transform: rotate(225deg);
     -webkit-transform: rotate(225deg);
 }
 
+.rl-step[data-id="0"] .rl-up-p,
+.rl-step.rl-last-step .rl-down-p {
+    cursor: not-allowed;
+    opacity: 0.3;
+    pointer-events: none;
+}


### PR DESCRIPTION
## Issue
When using the reorderable steps there was an issue with using trying to use the up arrow to place a step in the first position.
- Issue is addressed here: https://github.com/netizenorg/netnet.studio/pull/250#issuecomment-2417585041

## Changes
- Reworked and simplified the `moveSteps()` method to fix bug.

On top of the bug fix, I changed a few behaviors and styles with the reorderable list.
- For the first step the up arrow is disabled and for the last step the down arrow is disabled (with styling).
- When dragging a step it is 'highlighted' so users can better visualize their actions.
- Change some general classnames with `"rl-..."` to avoid CSS style conflicts in the future. (Example "`arrow`" to "`rl-arrow`")
- Added some different `cursor` CSS styles to elements. For example, the arrows now have a `pointer` cursor to indicate they are selectable.
- Moved the click event listeners for arrows on their parent element so users can click the space it takes up and not the small arrow character itself.