### PR TITLE
fixing lingering curtain bug

### DIFF
--- a/www/core/NetNetFaceMenu.js
+++ b/www/core/NetNetFaceMenu.js
@@ -232,6 +232,7 @@ class NetNetFaceMenu {
     this._faceAssets = { null: '' }
     let ready = false
     utils.get('api/face-assets', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
       json.forEach(svg => {
         const name = svg.split('.')[0]
         let key = name === 'mouth-dot' ? '.' : name

--- a/www/core/utils-convo.js
+++ b/www/core/utils-convo.js
@@ -1,4 +1,4 @@
-/* global utils, WIDGETS, NNW */
+/* global utils, WIDGETS, NNW, nn */
 window.CONVOS['utils-misc'] = (self) => {
   // TODO: consider moving these all into Widget convos
   // Maybe mostly to new Project Files (&& others, ex: Coding Menu, StudentSession)
@@ -18,6 +18,14 @@ window.CONVOS['utils-misc'] = (self) => {
     const o = WIDGETS['student-session'].getData('owner')
     return { u, o }
   })()
+
+  const f12 = nn.platformInfo().platform.includes('Mac') ? 'Fn + F12' : 'F12'
+  const safari = nn.platformInfo().name === 'Safari'
+  const errorFace = () => {
+    NNW.menu.updateFace({
+      leftEye: 'ŏ', mouth: '︵', rightEye: 'ŏ', lookAtCursor: false
+    })
+  }
 
   return [{
     id: 'remix-github-project-logged-out',
@@ -86,6 +94,26 @@ window.CONVOS['utils-misc'] = (self) => {
     content: 'You can access all the code related actions in the <b>Coding Menu</b> which you can open by clicking on my face. There you\'ll be able to save, open and create new sketchs or projects.',
     options: {
       'cool!': (e) => e.hide()
+    }
+  }, {
+    id: 'oh-no-error',
+    after: () => errorFace(),
+    content: 'Oh dang! seems there was a server error... sorry about that...',
+    options: {
+      'it\'s ok, errors are a part of the process': (e) => {
+        e.hide()
+        NNW.menu.switchFace('default')
+      },
+      'what was the error?': (e) => e.goTo('explain-error')
+    }
+  }, {
+    id: 'explain-error',
+    content: `The details are beyond my awareness, but if you're feeling curious you can investigate the issue yourself by pressing <code>${f12}</code> to open your browser developer tools ${safari ? '(You\'re using Safari, so you may need to enable you developer tools first)' : ''} and check the "Console". Then <a href="${window.location.origin}/docs/contributors/bug-report.html" target="_blank">report the issue</a> to let us know what you found!`,
+    options: {
+      ok: (e) => {
+        e.hide()
+        NNW.menu.switchFace('default')
+      }
     }
   }]
 }

--- a/www/core/utils.js
+++ b/www/core/utils.js
@@ -8,7 +8,11 @@ window.utils = {
         else return res.json()
       })
       .then(res => cb(res))
-      .catch(err => console.error(err))
+      .catch(err => {
+        console.error(err)
+        const errObj = { success: false, error: err }
+        if (cb) cb(errObj)
+      })
   },
 
   post: (url, data, cb) => {
@@ -23,7 +27,11 @@ window.utils = {
     window.fetch(url, opts)
       .then(res => res.json())
       .then(res => { if (cb) cb(res) })
-      .catch(err => console.error(err))
+      .catch(err => {
+        console.error(err)
+        const errObj = { success: false, error: err }
+        if (cb) cb(errObj)
+      })
   },
 
   getSync: async (url, text = false) => {
@@ -203,6 +211,10 @@ window.utils = {
     const a = window.utils.url.github.split('/')
     const data = { owner: a[0], repo: a[1], branch: a[2] }
     window.utils.post('./api/github/fork', data, (json) => {
+      if (!json.success) {
+        console.error(json)
+        return window.utils._Convo('oh-no-error')
+      }
       WIDGETS.open('project-files', (w) => w.openProject(json.data.name))
     })
   },
@@ -211,7 +223,8 @@ window.utils = {
     return nn.platformInfo().platform.includes('Mac') ? 'CMD' : 'CTRL'
   },
 
-  _Convo: (id) => {
+  _Convo: (id, err) => {
+    if (id === 'oh-no-error') console.error(err)
     Convo.load('/core/utils-convo.js', () => {
       const convos = window.CONVOS['utils-misc'](window.utils)
       window.convo = new Convo(convos, id)
@@ -518,6 +531,11 @@ window.utils = {
     const proxy = `${proto}//${host}/api/github/proxy?url=${base}/`
     const rawHTML = `${proxy}index.html`
     window.utils.get(rawHTML, (html) => {
+      if (typeof html !== 'string' || html === '{"error":"not_found"}') {
+        window.utils.fadeOutLoader(false)
+        window.utils._Convo('oh-no-error')
+        return
+      }
       window.utils.setCustomRenderer(base, proxy)
 
       NNE.code = ''

--- a/www/custom-elements/misc/load-curtain/index.js
+++ b/www/custom-elements/misc/load-curtain/index.js
@@ -2,6 +2,7 @@
 class LoadCurtain extends HTMLElement {
   show (filename, opts) {
     window.utils.get(`/custom-elements/misc/load-curtain/data/${filename}`, (html) => {
+      if (typeof html !== 'string') console.error('ERROR', html)
       this.setAttribute('id', 'curtain-loading-screen')
       if (opts) {
         for (const key in opts) {

--- a/www/custom-elements/misc/search-bar/index.js
+++ b/www/custom-elements/misc/search-bar/index.js
@@ -199,6 +199,7 @@ class SearchBar extends HTMLElement {
 
   _loadWidgetsData () {
     utils.get('./api/widgets', (list) => {
+      if (list.success === false) return utils._Convo('oh-no-error', list)
       const arr = []
       list.forEach(file => {
         file.keywords.push('widget')
@@ -217,6 +218,7 @@ class SearchBar extends HTMLElement {
   _loadTutorialsData () {
     this.loaded.tutorials = true
     utils.get('tutorials/list.json', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
       const arr = []
       let len = 0
       for (const sec in json) { len += json[sec].length }
@@ -225,6 +227,7 @@ class SearchBar extends HTMLElement {
       for (const sec in json) {
         json[sec].forEach(name => {
           utils.get(`tutorials/${name}/tutorial.json`, (tut) => {
+            if (tut.success === false) return utils._Convo('oh-no-error', tut)
             arr.push({
               type: 'Tutorials',
               word: tut.metadata.title,
@@ -240,6 +243,7 @@ class SearchBar extends HTMLElement {
     })
 
     utils.get('api/demos', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
       const arr = []
       const len = Object.keys(json.data).length
       const update = () => { if (arr.length === len) this.addToDict(arr) }
@@ -266,6 +270,7 @@ class SearchBar extends HTMLElement {
     })
 
     utils.get('api/templates', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
       const arr = []
       const len = Object.keys(json.data.list).length
       const update = () => { if (arr.length === len) this.addToDict(arr) }

--- a/www/widgets/convo-maker/index.js
+++ b/www/widgets/convo-maker/index.js
@@ -30,6 +30,7 @@ class ConvoMaker extends Widget {
       if (e.origin !== window.location.origin) return // for security
       if (e.data.type === 'cnvmkr-opened') {
         utils.get('/api/convos', (res) => {
+          if (res.success === false) return utils._Convo('oh-no-error', res)
           this.widgets = res.map(w => w.key)
           this._msgCnvMkr('widgets-list', res)
         })

--- a/www/widgets/css-reference/index.js
+++ b/www/widgets/css-reference/index.js
@@ -59,7 +59,10 @@ class CssReference extends Widget {
       NNE.cm.off('keydown', this._boundEditWatcher)
     })
 
-    utils.get('./widgets/css-reference/data/edu-supplement.json', (json) => { this.data = json })
+    utils.get('./widgets/css-reference/data/edu-supplement.json', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
+      this.data = json
+    })
     utils.get('./widgets/css-reference/data/main-slide.html', (html) => init(html), true)
   }
 

--- a/www/widgets/demo-maker/index.js
+++ b/www/widgets/demo-maker/index.js
@@ -20,6 +20,7 @@ class DemoMaker extends Widget {
     })
 
     utils.get('api/demos', (res) => {
+      if (res.success === false) return utils._Convo('oh-no-error', res)
       this.demos = res.data
       this._messagePopup('demo-list', this.demos)
     })

--- a/www/widgets/demo-sketches/index.js
+++ b/www/widgets/demo-sketches/index.js
@@ -15,6 +15,7 @@ class DemoSketches extends Widget {
     Convo.load(this.key, () => { this.convos = window.CONVOS[this.key](this) })
 
     utils.get('api/demos', (res) => {
+      if (res.success === false) return utils._Convo('oh-no-error', res)
       this.demos = res.data
       Object.entries(this.demos).forEach(a => this._createDemoItem(a))
     })
@@ -266,6 +267,7 @@ class DemoSketches extends Widget {
         this._resizePreview()
         this._updateEditor('#code/eJzT09PLyU9MycxL19PTAwAbtAPz') // loading text
         utils.get(`api/demo/${o.key}`, (demo) => {
+          if (demo.success === false) return utils._Convo('oh-no-error', demo)
           this.editor.code = NNE._decode(demo.code.substr(6))
         })
       }, 500)

--- a/www/widgets/demo-toc/index.js
+++ b/www/widgets/demo-toc/index.js
@@ -43,7 +43,10 @@ class DemoToc extends Widget {
     const isNum = (typeof code === 'number' || (typeof num === 'number' && !isNaN(num)))
 
     if (isNum) {
-      utils.get(`./api/demo/${num}`, json => this._load(json, type))
+      utils.get(`./api/demo/${num}`, json => {
+        if (json.success === false) return utils._Convo('oh-no-error', json)
+        this._load(json, type)
+      })
     } else if (typeof code === 'object' && typeof code.code === 'string') {
       this._load(code, type)
     }

--- a/www/widgets/git-push/convo.js
+++ b/www/widgets/git-push/convo.js
@@ -129,12 +129,20 @@ window.CONVOS['git-push'] = (self) => {
     after: () => errorFace(),
     content: 'Oh dang! seems there was a server error... sorry about that...',
     options: {
-      'it\'s ok, errors are a part of the process': (e) => e.hide(),
+      'it\'s ok, errors are a part of the process': (e) => {
+        e.hide()
+        NNW.menu.switchFace('default')
+      },
       'what was the error?': (e) => e.goTo('explain-error')
     }
   }, {
     id: 'explain-error',
     content: `The details are beyond my awareness, but if you're feeling curious you can investigate the issue yourself by pressing <code>${f12}</code> to open your browser developer tools ${safari ? '(You\'re using Safari, so you may need to enable you developer tools first)' : ''} and check the "Console". Then <a href="${window.location.origin}/docs/contributors/bug-report.html" target="_blank">report the issue</a> to let us know what you found!`,
-    options: { ok: (e) => e.hide() }
+    options: {
+      ok: (e) => {
+        e.hide()
+        NNW.menu.switchFace('default')
+      }
+    }
   }]
 }

--- a/www/widgets/git-push/index.js
+++ b/www/widgets/git-push/index.js
@@ -1,4 +1,4 @@
-/* global Widget, Convo, WIDGETS, NNW, nn, utils */
+/* global Widget, Convo, WIDGETS, nn, utils */
 class GitPush extends Widget {
   constructor (opts) {
     super(opts)

--- a/www/widgets/git-push/index.js
+++ b/www/widgets/git-push/index.js
@@ -186,8 +186,8 @@ class GitPush extends Widget {
               this._nextCmd('finished')
             } else {
               console.log('GIT SERVER ERROR:', json)
-              const face = { leftEye: 'ŏ', mouth: '︵', rightEye: 'ŏ', lookAtCursor: false }
-              NNW.menu.updateFace(face)
+              nn.get('load-curtain').hide()
+              window.convo = new Convo(this.convos, 'oh-no-error')
             }
           })
         },

--- a/www/widgets/html-reference/index.js
+++ b/www/widgets/html-reference/index.js
@@ -16,7 +16,10 @@ class HtmlReference extends Widget {
 
     Convo.load(this.key, () => { this.convos = window.CONVOS[this.key](this) })
 
-    utils.get('./widgets/html-reference/data/edu-supplement.json', (json) => { this.data = json })
+    utils.get('./widgets/html-reference/data/edu-supplement.json', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
+      this.data = json
+    })
 
     utils.get('./widgets/html-reference/data/main-slide.html', (html) => {
       // options objects for <widget-slide> .updateSlide() method

--- a/www/widgets/hyper-video-player/index.js
+++ b/www/widgets/hyper-video-player/index.js
@@ -59,7 +59,10 @@ class HyperVideoPlayer extends Widget {
   load (name, time) {
     nn.get('load-curtain').show('tutorial.html')
     utils.get(`tutorials/${name}/tutorial.json`, (json) => {
-      if (json.success === false) return utils._Convo('oh-no-error', json)
+      if (json.success === false) {
+        setTimeout(() => nn.get('load-curtain').hide(), 250)
+        return utils._Convo('oh-no-error', json)
+      }
       this.data = json
       this._startTime = time || 0
 

--- a/www/widgets/hyper-video-player/index.js
+++ b/www/widgets/hyper-video-player/index.js
@@ -59,6 +59,7 @@ class HyperVideoPlayer extends Widget {
   load (name, time) {
     nn.get('load-curtain').show('tutorial.html')
     utils.get(`tutorials/${name}/tutorial.json`, (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
       this.data = json
       this._startTime = time || 0
 

--- a/www/widgets/js-reference/index.js
+++ b/www/widgets/js-reference/index.js
@@ -11,7 +11,10 @@ class JsReference extends Widget {
 
     // this.on('close', () => { this.slide.updateSlide(this.mainOpts) })
 
-    utils.get('./widgets/js-reference/data/edu-supplement.json', (json) => { this.data = json })
+    utils.get('./widgets/js-reference/data/edu-supplement.json', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
+      this.data = json
+    })
 
     utils.get('./widgets/js-reference/data/main-slide.html', (html) => {
       const div = nn.create('div').content(html)

--- a/www/widgets/learning-guide/index.js
+++ b/www/widgets/learning-guide/index.js
@@ -318,6 +318,7 @@ class LearningGuide extends Widget {
     // Load all the Tutorial Data the Learning Guide needs
     // ........................
     utils.get('tutorials/list.json', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
       Object.entries(json).forEach(([key, val]) => {
         this.tutorials[key] = []
         val.forEach(n => {

--- a/www/widgets/lingo-glossary/index.js
+++ b/www/widgets/lingo-glossary/index.js
@@ -14,6 +14,7 @@ class LingoGlossary extends Widget {
     Convo.load(this.key, () => { this.convos = window.CONVOS[this.key](this) })
 
     utils.get('/widgets/lingo-glossary/data.json', (data) => {
+      if (data.success === false) return utils._Convo('oh-no-error', data)
       this.dict = Object.fromEntries(
         Object.entries(data).sort(([a], [b]) => a.localeCompare(b))
       )
@@ -134,8 +135,6 @@ class LingoGlossary extends Widget {
     if (wig === 'demo-sketches') txt = 'open demo in new tab'
     else if (wig.includes('-reference')) txt = `open ${lan} docs`
     else if (wig === 'open') txt = 'open widget'
-
-    console.log(wig);
 
     nn.create('span')
       .set('class', 'pill-btn pill-btn--secondary')

--- a/www/widgets/project-files/index.js
+++ b/www/widgets/project-files/index.js
@@ -1,4 +1,4 @@
-/* global NNE, NNW, WIDGETS, Widget, Convo, utils, nn, JSZip */
+/* global NNE, NNW, WIDGETS, Widget, Convo, utils, nn */
 /*
 
 this widget is used to store project files in local storage, it works in tandem
@@ -442,7 +442,7 @@ class ProjectFiles extends Widget {
 
       // load data for all the files
       utils.post('./api/github/open-all-files', { repo, owner }, async (res) => {
-        if (!res.success) {
+        if (res.success === 'false') {
           nn.get('load-curtain').hide()
           return this._ohNoErr(res)
         }
@@ -1586,7 +1586,6 @@ class ProjectFiles extends Widget {
       window.convo = new Convo(this.convos, 'duplicate-file')
       this._uploadedFile = {}
     } else {
-      console.log('showing curtain...');
       nn.get('load-curtain').show('upload.html', { filename: file.name })
       const isTextType = this._isTxt(file.name, type)
       const reader = new window.FileReader()
@@ -1601,9 +1600,16 @@ class ProjectFiles extends Widget {
         const filepath = path ? `${path}/${file.name}` : file.name
         await this._updateFile(filepath, data)
         this._updateFilesGUI()
-        console.log('hiding curtain...');
         setTimeout(() => nn.get('load-curtain').hide(), 200)
         this._uploadedFile = {}
+      }
+      reader.onerror = (err) => {
+        utils._Convo('oh-no-error', err)
+        setTimeout(() => nn.get('load-curtain').hide(), 200)
+      }
+      reader.onabort = () => {
+        console.log('ProjectFiles: read file aborted')
+        setTimeout(() => nn.get('load-curtain').hide(), 200)
       }
       if (isTextType) reader.readAsText(file)
       else reader.readAsDataURL(file)

--- a/www/widgets/project-files/index.js
+++ b/www/widgets/project-files/index.js
@@ -562,6 +562,7 @@ class ProjectFiles extends Widget {
     }
     utils.post('./api/github/gh-pages', data, (res) => {
       if (!res.success) {
+        nn.get('load-curtain').hide()
         window.convo = new Convo(this.convos, 'oh-no-error')
       } else {
         this.projectData.ghpages = res.data.html_url

--- a/www/widgets/student-session/index.js
+++ b/www/widgets/student-session/index.js
@@ -169,6 +169,7 @@ class StudentSession extends Widget {
       window.localStorage.setItem('gh-auth-temp-code', '__TEMP__' + utils.url.template)
     } else window.localStorage.setItem('gh-auth-temp-code', code)
     utils.get('api/github/client-id', (json) => {
+      if (json.success === false) return utils._Convo('oh-no-error', json)
       const id = `client_id=${json.message}`
       const scope = 'scope=public_repo'
       const url = `https://github.com/login/oauth/authorize?${id}&${scope}`


### PR DESCRIPTION
`utils.get` and `utils.post` now do a better job of returning errors which means we can catch and report those via netnet `utils._Convo('oh-no-error', err)` if we ever show a curtain, we should hide it if an error prevents logic from running (which had otherwise included the call to `.hide()` the curtain)